### PR TITLE
Don't return failed exit code when $_ZL_ECHO is unbind

### DIFF
--- a/z.lua
+++ b/z.lua
@@ -1311,7 +1311,9 @@ _zlua() {
 			else
 				$_ZL_CD "$dest"
 			fi
-			[ -n "$_ZL_ECHO" ] && pwd
+			if [ -n "$_ZL_ECHO" ]; then
+				pwd
+			fi
 		fi
 	fi
 }


### PR DESCRIPTION
Using the "&&" operator returns the exit code of the first failed
command, and when `$_ZL_ECHO` is unbind always return 1.