### PR TITLE
fix: no more lua_XXXXXX temp files

### DIFF
--- a/z.lua
+++ b/z.lua
@@ -525,7 +525,9 @@ function math.random_init()
 	if rnd ~= nil then
 		seed = seed .. rnd
 	end
-	seed = seed .. os.tmpname()
+    local tmpname = os.tmpname()
+	seed = seed .. tmpname
+    os.remove(tmpname)
 	local number = 0
 	for i = 1, seed:len() do
 		local k = string.byte(seed:sub(i, i))
@@ -620,8 +622,7 @@ function data_save(filename, M)
 	else
 		math.random_init()
 		tmpname = filename .. '.' .. math.random_string(6)
-		local sub = (os.tmpname()):sub(-6, -1):gsub('[\\/:~]', '')
-		tmpname = tmpname .. sub .. tostring(os.time())
+		tmpname = tmpname .. tostring(os.time())
 		local rnd = os.getenv('_ZL_RANDOM')
 		tmpname = tmpname .. '' .. (rnd and rnd or '')
 		-- print('tmpname: '..tmpname)

--- a/z.lua
+++ b/z.lua
@@ -525,9 +525,9 @@ function math.random_init()
 	if rnd ~= nil then
 		seed = seed .. rnd
 	end
-    local tmpname = os.tmpname()
+	local tmpname = os.tmpname()
 	seed = seed .. tmpname
-    os.remove(tmpname)
+	os.remove(tmpname)
 	local number = 0
 	for i = 1, seed:len() do
 		local k = string.byte(seed:sub(i, i))


### PR DESCRIPTION
Every time you changed dir, there will be a lua_XXXXXX file created in /tmp, and will not be removed. These files is created by `os.tmpname()`, there are two calls in z.lua:

1. `os.tmpname()` in `math.random_init` is used to create a random string for seed. We need to delete tmp file after use.
2. `os.tmpname()` in `data_save` also used to create a random string for tmp db file,  for example `tmpname: /Users/fannheyward/.zlua.RK2Nq7qjU1E6154899255913512`. In this case, the sub string is not needed, cause the `tmpname` already has random string by `math.random_string` and `os.time()` for timestamp, so just delete `os.tmpname()` calls.