### PR TITLE
Use \which in case user has it aliased to type -a

### DIFF
--- a/z.lua.plugin.zsh
+++ b/z.lua.plugin.zsh
@@ -6,14 +6,14 @@ ZLUA_SCRIPT="${0:A:h}/z.lua"
 
 # search lua executable
 if [[ -z "$ZLUA_EXEC" ]]; then
-	if [[ -x "$(which lua)" ]]; then
-		ZLUA_EXEC="$(which lua)"
+	if [[ -x "$(\which lua)" ]]; then
+		ZLUA_EXEC="$(\which lua)"
 	elif [[ -x "$(which lua5.3)" ]]; then
-		ZLUA_EXEC="$(which lua5.3)"
+		ZLUA_EXEC="$(\which lua5.3)"
 	elif [[ -x "$(which lua5.2)" ]]; then
-		ZLUA_EXEC="$(which lua5.2)"
+		ZLUA_EXEC="$(\which lua5.2)"
 	elif [[ -x "$(which lua5.1)" ]]; then
-		ZLUA_EXEC="$(which lua5.1)"
+		ZLUA_EXEC="$(\which lua5.1)"
 	else
 		echo "Not find lua in your $PATH, please install it."
 		return


### PR DESCRIPTION
z.lua didn't work for me because it couldn't find lua because I had `which` aliased to `type -a`. `\which` will use the non-aliased version.