### PR TITLE
remove unnecessary fzf hard code opts

### DIFF
--- a/z.lua
+++ b/z.lua
@@ -1590,7 +1590,7 @@ function z_cd(patterns)
 	elseif Z_INTERACTIVE == 2 then
 		local fzf = os.environ('_ZL_FZF', 'fzf')
 		local tmpname = '/tmp/zlua.txt'
-		local cmd = '--nth 2.. --reverse --inline-info --tac '
+		local cmd = '--nth 2.. --tac'
 		local flag = os.environ('_ZL_FZF_FLAG', '')
 		flag = (flag == '' or flag == nil) and '+s -e' or flag
 		cmd = ((fzf == '') and 'fzf' or fzf)  .. ' ' .. cmd .. ' ' .. flag

--- a/z.lua.plugin.zsh
+++ b/z.lua.plugin.zsh
@@ -32,3 +32,25 @@ alias zb='z -b'
 alias zh='z -I -t .'
 alias zzc='zz -c'
 
+fzf-zlua-widget() {
+    _zlua -I . 
+    local ret=$?
+    zle reset-prompt
+    return $ret
+}
+
+fzf-zlua-stack-widget() {
+    LBUFFER="${LBUFFER}$(z -- 2>&1 | fzf --height 25% | awk '{print $2}')"
+    local ret=$?
+    zle redisplay
+    if [[ $ret == 0 && -o auto_cd && -n $BUFFER ]]; then
+        zle .accept-line
+    fi
+    return $ret
+}
+
+zle -N fzf-zlua-widget
+bindkey "^G" fzf-zlua-widget
+
+zle -N fzf-zlua-stack-widget
+bindkey "^S" fzf-zlua-stack-widget


### PR DESCRIPTION
I think '--reverse --inline-info' is unnecessary fzf ops. It's very hard code in local cmd inside lua script.
User can use $_ZL_FZF_FLAG env instead of using hard code inside lua script.