### PR TITLE
Fix bug in ranger plugin

### DIFF
--- a/ranger_zlua.py
+++ b/ranger_zlua.py
@@ -59,7 +59,6 @@ class z(ranger.api.commands.Command):
                     cmd += ' "%s"'%arg
                 if mode in ('-e', '-x'):
                     path = subprocess.check_output([PATH_LUA, PATH_ZLUA, '--cd'] + args)
-                    path = path.decode("utf-8", "ignore")
                     path = path.rstrip('\n')
                     self.fm.notify(path)
                 elif mode in ('-h', '-l', '--help'):
@@ -81,7 +80,6 @@ class z(ranger.api.commands.Command):
                         self.fm.cd(path)
             else:
                 path = subprocess.check_output([PATH_LUA, PATH_ZLUA, '--cd'] + args)
-                path = path.decode("utf-8", "ignore")
                 path = path.rstrip('\n')
                 if path and os.path.exists(path):
                     self.fm.cd(path)


### PR DESCRIPTION
These two lines seem unnecessary. And in fact, these lines cause errors when trying to change to directory with Chinese characters. with ranger version
Error message: 'ascii' codec can't encode characters in position 23-24: ordinal not in range(128)
Machine information: Ubuntu 18.04 ranger: 1.8.1 python 2.7
After I remove these two lines, it works perfect.