### PR TITLE
Do not append semicolon to PROMPT_COMMAND

### DIFF
--- a/z.lua
+++ b/z.lua
@@ -2010,14 +2010,14 @@ alias ${_ZL_CMD:-z}='_zlua'
 local script_init_bash = [[
 case "$PROMPT_COMMAND" in
 	*_zlua?--add*) ;;
-	*) PROMPT_COMMAND="(_zlua --add \"\$(command pwd 2>/dev/null)\" &);$PROMPT_COMMAND" ;;
+	*) PROMPT_COMMAND="(_zlua --add \"\$(command pwd 2>/dev/null)\" &)${PROMPT_COMMAND:+;$PROMPT_COMMAND}" ;;
 esac
 ]]
 
 local script_init_bash_fast = [[
 case "$PROMPT_COMMAND" in
 	*_zlua?--add*) ;;
-	*) PROMPT_COMMAND="(_zlua --add \"\$PWD\" &);$PROMPT_COMMAND" ;;
+	*) PROMPT_COMMAND="(_zlua --add \"\$PWD\" &)${PROMPT_COMMAND:+;$PROMPT_COMMAND}" ;;
 esac
 ]]
 
@@ -2029,7 +2029,7 @@ _zlua_precmd() {
 }
 case "$PROMPT_COMMAND" in
 	*_zlua_precmd*) ;;
-	*) PROMPT_COMMAND="_zlua_precmd;$PROMPT_COMMAND" ;;
+	*) PROMPT_COMMAND="_zlua_precmd${PROMPT_COMMAND:+;$PROMPT_COMMAND}" ;;
 esac
 ]]
 


### PR DESCRIPTION
When sourcing `z.lua` a semicolon is added to the end of `PROMPT_COMMAND`. That makes adding additional commands to `PROMPT_COMMAND` more cumbersome because it requires checking for the last `;` character instead of only checking if the variable exists. Having two semicolons in `PROMPT_COMMAND` is an error. 

For example (from my bashrc):
```
if ! [[ "${PROMPT_COMMAND:-}" =~ __prompt_command ]]; then
        PROMPT_COMMAND="__prompt_command${PROMPT_COMMAND:+;$PROMPT_COMMAND};__precmd"
fi
```
won't work because `z.lua` added a semicolon to `PROMPT_COMMAND` and bash will complain about syntax error near unexpected token `;;`