### PR TITLE
Setting zsh-hooks to be unique is not necessary

### DIFF
--- a/z.lua
+++ b/z.lua
@@ -2056,7 +2056,7 @@ local script_init_zsh = [[
 _zlua_precmd() {
 	(_zlua --add "${PWD:a}" &)
 }
-typeset -gaU precmd_functions
+typeset -ga precmd_functions
 [ -n "${precmd_functions[(r)_zlua_precmd]}" ] || {
 	precmd_functions[$(($#precmd_functions+1))]=_zlua_precmd
 }
@@ -2066,7 +2066,7 @@ local script_init_zsh_once = [[
 _zlua_precmd() {
 	(_zlua --add "${PWD:a}" &)
 }
-typeset -gaU chpwd_functions
+typeset -ga chpwd_functions
 [ -n "${chpwd_functions[(r)_zlua_precmd]}" ] || {
 	chpwd_functions[$(($#chpwd_functions+1))]=_zlua_precmd
 }


### PR DESCRIPTION
z.lua unnecessarily changes zsh hooks to be `unique`. This slightly changes the default behaviour of zsh hooks and is actually not needed because there's a check for the presence of `_zlua_precmd` on the following line. 