### PR TITLE
[zsh plugin] allow the user to customize _ZL_FZF_FLAG beforehand

### DIFF
--- a/z.lua.plugin.zsh
+++ b/z.lua.plugin.zsh
@@ -20,7 +20,7 @@ if [[ -z "$ZLUA_EXEC" ]]; then
 	fi
 fi
 
-export _ZL_FZF_FLAG="-e"
+export _ZL_FZF_FLAG=${_ZL_FZF_FLAG:-"-e"}
 
 eval "$($ZLUA_EXEC $ZLUA_SCRIPT --init zsh once enhanced)"
 


### PR DESCRIPTION
Increase flexibility: allow the user to customize _ZL_FZF_FLAG before the zsh plugin is loaded