### PR TITLE
Introduce _ZL_NO_ALIASES to skip creating aliases

### DIFF
--- a/z.lua.plugin.zsh
+++ b/z.lua.plugin.zsh
@@ -24,11 +24,11 @@ export _ZL_FZF_FLAG=${_ZL_FZF_FLAG:-"-e"}
 
 eval "$($ZLUA_EXEC $ZLUA_SCRIPT --init zsh once enhanced)"
 
-
-alias zz='z -i'
-alias zc='z -c'
-alias zf='z -I'
-alias zb='z -b'
-alias zh='z -I -t .'
-alias zzc='zz -c'
-
+if [[ -z "$_ZL_NO_ALIASES" ]]; then
+  alias zz='z -i'
+  alias zc='z -c'
+  alias zf='z -I'
+  alias zb='z -b'
+  alias zh='z -I -t .'
+  alias zzc='zz -c'
+fi


### PR DESCRIPTION
aliases are broken if _ZL_CMD is set to anything other than z