### PR TITLE
Improve zsh's completion

### DIFF
--- a/z.lua
+++ b/z.lua
@@ -2201,12 +2201,11 @@ fi
 local script_complete_zsh = [[
 _zlua_zsh_tab_completion() {
 	# tab completion
-	local compl
-	read -l compl
 	(( $+compstate )) && compstate[insert]=menu # no expand
-	reply=(${(f)"$(_zlua --complete "$compl")"})
+	local -a tmp=(${(f)"$(_zlua --complete "${words/_zlua/z}")"})
+	_describe "directory" tmp -U
 }
-compctl -U -K _zlua_zsh_tab_completion _zlua
+compdef _zlua_zsh_tab_completion _zlua
 ]]
 
 


### PR DESCRIPTION
`compctl` is ancient and many users even [completly disable it](https://github.com/search?q=zstyle+%27%3Acompletion%3A*%27+use-compctl+false&type=Code).
This PR replace it with mordern [compsys](http://zsh.sourceforge.net/Doc/Release/Completion-System.html).

Related issue: [fzf-tab#44](https://github.com/Aloxaf/fzf-tab/issues/44)