### PR TITLE
Use `command -v` to reduce zsh startup time

### DIFF
--- a/z.lua.plugin.zsh
+++ b/z.lua.plugin.zsh
@@ -6,15 +6,11 @@ ZLUA_SCRIPT="${0:A:h}/z.lua"
 
 # search lua executable
 if [[ -z "$ZLUA_EXEC" ]]; then
-	if [[ -x "$(command which lua)" ]]; then
-		ZLUA_EXEC="$(command which lua)"
-	elif [[ -x "$(command which lua5.3)" ]]; then
-		ZLUA_EXEC="$(command which lua5.3)"
-	elif [[ -x "$(command which lua5.2)" ]]; then
-		ZLUA_EXEC="$(command which lua5.2)"
-	elif [[ -x "$(command which lua5.1)" ]]; then
-		ZLUA_EXEC="$(command which lua5.1)"
-	else
+	for lua in lua lua5.3 lua5.2 lua5.1; do
+		ZLUA_EXEC="$(command -v "$lua")"
+		[[ -n "$ZLUA_EXEC" ]] && break
+	done
+	if [[ -z "$ZLUA_EXEC" ]]; then
 		echo "Not find lua in your $PATH, please install it."
 		return
 	fi


### PR DESCRIPTION
`which` is very slow.

Simple benchmark:
```
# before
$ time ( for i in {1..100}; do zsh z.lua.plugin.zsh; done )
18.54s user 2.29s system 102% cpu 20.340 total
# after
$ time ( for i in {1..100}; do zsh z.lua.plugin.zsh; done )
0.84s user 0.37s system 104% cpu 1.164 total
```

22 times faster!