### PR TITLE
Fix `z -I` in ranger_zlua.py

### DIFF
--- a/ranger_zlua.py
+++ b/ranger_zlua.py
@@ -69,14 +69,10 @@ class z(ranger.api.commands.Command):
                     p = self.fm.execute_command(cmd + ' 2>&1 | less +G', universal_newlines=True)
                     stdout, stderr = p.communicate()
                 else:
-                    if mode == '-I':
-                        os.environ['_ZL_FZF_HEIGHT'] = '0'
-                        path = subprocess.check_output([PATH_LUA, PATH_ZLUA, '--cd'] + args)
-                        self.fm.execute_console('redraw_window')
-                    else:
-                        p = self.fm.execute_command(cmd, universal_newlines=True, stdout=subprocess.PIPE)
-                        stdout, stderr = p.communicate()
-                        path = stdout.rstrip('\n')
+                    p = self.fm.execute_command(cmd, universal_newlines=True, stdout=subprocess.PIPE)
+                    stdout, stderr = p.communicate()
+                    path = stdout.rstrip('\n')
+                    self.fm.execute_console('redraw_window')
                     if path and os.path.exists(path):
                         self.fm.cd(path)
             else:


### PR DESCRIPTION
`z -I` had 2 issues:
- it used  `subprocess.check_output()`, but didn't UTF-8 decode the string (like the `if mode` statement's `else` branch does on row 80)
- it wasn't actually interactive, like `-I` is supposed to be (subprocess.check_output()` is not interactive)

I'm not sure why `-I` mode was originally treated differently from e.g. `-i` mode, but the same code works for both.

I took the `redraw_window` console command from the original `-I` mode code, because without it the screen updates a bit slower, causing an ugly "flash".