### PR TITLE
add _ZL_CLINK_PROMPT_PRIORITY set clink prompt register priority.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ z -b foo    # cd to the parent directory starting with foo
 - set `$_ZL_MATCH_MODE` to 1 to enable enhanced matching.
 - set `$_ZL_NO_CHECK` to 1 to disable path validation, use `z --purge` to clean
 - set `$_ZL_HYPHEN` to 1 to treat hyphon (-) as a normal character not a lua regexp keyword.
+- set `$_ZL_CLINK_PROMPT_PRIORITY` change clink prompt register priority (default 99).
 
 ## Aging
 

--- a/z.lua
+++ b/z.lua
@@ -2059,6 +2059,7 @@ end
 -----------------------------------------------------------------------
 function z_clink_init()
 	local once = os.environ("_ZL_ADD_ONCE", false)
+	local _zl_clink_prompt_priority = os.environ('_ZL_CLINK_PROMPT_PRIORITY', 99)
 	local previous = ''
 	function z_add_to_database()
 		pwd = clink.get_cwd()
@@ -2070,7 +2071,7 @@ function z_clink_init()
 		end
 		z_add(clink.get_cwd())
 	end
-	clink.prompt.register_filter(z_add_to_database, 99)
+	clink.prompt.register_filter(z_add_to_database, _zl_clink_prompt_priority)
 	function z_match_completion(word)
 		local M = z_match({word}, Z_METHOD, Z_SUBDIR)
 		for _, item in pairs(M) do


### PR DESCRIPTION
if other prompt_filter priority greater than z.lua's priority , and return true, z.lua will not register prompt success.