### PR TITLE
Add flags to the `z` arg matcher for Clink.

### DIFF
--- a/z.lua
+++ b/z.lua
@@ -2081,6 +2081,7 @@ function z_clink_init()
 	end
 	local z_parser = clink.arg.new_parser()
 	z_parser:set_arguments({ z_match_completion })
+	z_parser:set_flags("-c", "-r", "-i", "--cd", "-e", "-b", "--add", "-x", "--purge", "--init", "-l", "-s", "--complete", "--help", "-h")
 	clink.arg.register_parser("z", z_parser)
 end
 


### PR DESCRIPTION
This makes `z -` have the available flags show up as completions.

Note:  requires either Clink <= v0.4.9 or Clink >= v1.1.**13**, which is not yet published.  Making this change in z.lua helped me find a bug in Clink v1.1.12 where backward compatibility for `clink.arg.register_parser` wasn't working properly.  The fixed Clink v1.1.13 will be published later today or tomorrow.  The change here can be tested and verified in Clink v0.4.x, though.

UPDATE:  Clink v1.1.13 has been published and the change in this PR should work properly with it.

E.g.
- `z -` <kbd>Alt</kbd>+<kbd>=</kbd> should list the flags as completions.
- `z -` <kbd>Tab</kbd> should list the flags as completions (or if bound to `menu-complete` then it should cycle through inserting different flags, etc).