### PR TITLE
Fix leaked pushd

### DIFF
--- a/z.cmd
+++ b/z.cmd
@@ -113,9 +113,7 @@ if /i "%RunMode%"=="-n" (
 	call "%LuaExe%" "%LuaScript%" "%RunMode%" %MatchType% %StrictSub% %InterMode% %StripMode% %*
 )
 
-:end
-echo.
-goto :eof
+goto end
 
 :popdir
 rem -- Exploits variable expansion and the pushd stack to set the current
@@ -124,3 +122,7 @@ popd
 setlocal
 set NewPath=%CD%
 endlocal & popd & cd /d "%NewPath%"
+
+:end
+echo.
+

--- a/z.cmd
+++ b/z.cmd
@@ -124,4 +124,3 @@ popd
 setlocal
 set NewPath=%CD%
 endlocal & popd & cd /d "%NewPath%"
-

--- a/z.cmd
+++ b/z.cmd
@@ -106,7 +106,7 @@ if /i "%RunMode%"=="-n" (
 			pushd !NewPath!
 			pushd !NewPath!
 			endlocal
-			popd
+			goto popdir
 		)
 	)
 )	else (
@@ -115,4 +115,13 @@ if /i "%RunMode%"=="-n" (
 
 :end
 echo.
+goto :eof
+
+:popdir
+rem -- Exploits variable expansion and the pushd stack to set the current
+rem -- directory without leaking a pushd.
+popd
+setlocal
+set NewPath=%CD%
+endlocal & popd & cd /d "%NewPath%"
 


### PR DESCRIPTION
`z somedir` uses double `pushd` to tunnel the new path out past the
endlocal that restores the environment state.  But it ended up leaving
a pushd on the dir stack.

This change exploits normal variable expansion to restore the dir stack
to its initial state while still successfully tunneling the new path out
past the endlocal.