### PR TITLE
Add default to docs for $_ZL_CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ z -b foo    # cd to the parent directory starting with foo
 - set `$_ZL_EXCLUDE_DIRS` to a comma separated list of dirs to exclude.
 - set `$_ZL_ADD_ONCE` to '1' to update database only if `$PWD` changed.
 - set `$_ZL_MAXAGE` to define a aging threshold (default is 5000).
-- set `$_ZL_CD` to specify your own cd command.
+- set `$_ZL_CD` to specify your own cd command (default is `builtin cd` in Unix shells).
 - set `$_ZL_ECHO` to 1 to display new directory name after cd.
 - set `$_ZL_MATCH_MODE` to 1 to enable enhanced matching.
 - set `$_ZL_NO_CHECK` to 1 to disable path validation, use `z --purge` to clean


### PR DESCRIPTION
I don't know if the default of `builtin cd` is a good one, as opposed to a simple `cd`. It took me quite a bit of debugging before I figured out why, on my `fish` shell, changing directories with `z.lua` messed up the `cdh` (cd history) command. (On `fish`, `cd` is a function by default. It records the current directory in the history and then calls `builtin cd`).

I think the best thing would be to change the default. However, if you have a good reason to stick with it, I thought that documenting this potentially unexpected behavior might help.

Thank you, I really like using `z.lua`!