### PR TITLE
Improve Fish installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ To enable this, you can set `$_ZL_ADD_ONCE` to `1` before init z.lua. Or you can
 ````bash
 eval "$(lua /path/to/z.lua --init bash once)"
 eval "$(lua /path/to/z.lua --init zsh once)"
-source (lua /path/to/z.lua --init fish once | psub)
+lua /path/to/z.lua --init fish once | source
 ````
 
 With `add once` mode off (default), z.lua will consider the time you spent in the directory (like z.sh). When this mode is on, consider the times you accessed the directory (like autojump), and that could be much faster on slow hardware. 

--- a/README.md
+++ b/README.md
@@ -105,17 +105,17 @@ z -b foo    # cd to the parent directory starting with foo
 
   To generate old posix compatible script.
 
-- Fish Shell:
+- Fish Shell (version `2.4.0` or above):
 
   Create `~/.config/fish/conf.d/z.fish` with following code
 
-      source (lua /path/to/z.lua --init fish | psub)
+      lua /path/to/z.lua --init fish | source 
+  
+  If you'd like `z.lua` to cooperate with fish's own [directory history](https://fishshell.com/docs/3.2/index.html#id34), you can put
 
-  Fish version `2.4.0` or above is required. 
+      set -gx _ZL_CD cd
 
-      lua /path/to/z.lua --init fish > ~/.config/fish/conf.d/z.fish
-
-  This is another way to initialize z.lua in fish shell, but remember to regenerate z.fish if z.lua has been updated or moved.
+  into the same file.
 
 - Power Shell:
 

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ z -b foo    # cd to the parent directory starting with foo
 
   Create `~/.config/fish/conf.d/z.fish` with following code
 
-      lua /path/to/z.lua --init fish | source 
-  
+      lua /path/to/z.lua --init fish | source
+
   If you'd like `z.lua` to cooperate with fish's own [directory history](https://fishshell.com/docs/3.2/index.html#id34), you can put
 
       set -gx _ZL_CD cd


### PR DESCRIPTION
Most notably, this adds instructions of changing $_Z_CD.  I think many
`fish` users would find them useful. See #131 for more background.

This makes the installation instructions more conventional ([`|source`  instead of `psub`](https://fishshell.com/docs/current/fish_for_bash_users.html?highlight=psub#process-substitution)).
This also deletes the second (equivalent) set of instructions.

If the warning in that deleted sentence is important, we could add it back, but
it would apply to all the shells, wouldn't it? We could also de-emphasize it
by making it just a warning, something like

> You can instead manually insert the output of `lua /path/to/z.lua --init fish` 
> into the file, but then make sure to regenerate it every time you update or move `z.lua`.

Finally, some wording is improved.