### PR TITLE
[WIP] cmd: don't ignore _ZL_CD and allow relative paths

### DIFF
--- a/z.cmd
+++ b/z.cmd
@@ -112,8 +112,6 @@ if /i "%RunMode%"=="-n" (
 			pushd !NewPath!
 			endlocal
 			goto popdir
-		) else (
-			echo The system cannot find the path specified.
 		)
 	)
 )	else (

--- a/z.cmd
+++ b/z.cmd
@@ -98,6 +98,11 @@ for /f "delims=" %%i in ('cd') do set "PWD=%%i"
 
 if /i "%RunMode%"=="-n" (
 	for /f "delims=" %%i in ('call "%LuaExe%" "%LuaScript%" --cd %MatchType% %StrictSub% %InterMode% %*') do set "NewPath=%%i"
+	if "!NewPath!"=="" (
+		set NewPath=%1
+		call :normalizepath !NewPath!
+		set NewPath=!retval!
+	)
 	if not "!NewPath!"=="" (
 		if exist !NewPath!\nul (
 			if /i not "%_ZL_ECHO%"=="" (
@@ -107,6 +112,8 @@ if /i "%RunMode%"=="-n" (
 			pushd !NewPath!
 			endlocal
 			goto popdir
+		) else (
+			echo The system cannot find the path specified.
 		)
 	)
 )	else (
@@ -121,8 +128,16 @@ rem -- directory without leaking a pushd.
 popd
 setlocal
 set NewPath=%CD%
-endlocal & popd & cd /d "%NewPath%"
+set "CDCmd=cd /d"
+if /i not "%_ZL_CD%"=="" (
+	set "CDCmd=%_ZL_CD%"
+)
+endlocal & popd & %CDCmd% "%NewPath%"
 
 :end
 echo.
+exit /B
 
+:normalizepath
+set retval=%~f1
+exit /B

--- a/z.lua
+++ b/z.lua
@@ -2544,6 +2544,11 @@ if /i "%1"=="" (
 for /f "delims=" %%i in ('cd') do set "PWD=%%i"
 if /i "%RunMode%"=="-n" (
 	for /f "delims=" %%i in ('call "%LuaExe%" "%LuaScript%" --cd %MatchType% %StrictSub% %InterMode% %*') do set "NewPath=%%i"
+	if "!NewPath!"=="" (
+		set NewPath=%1
+		call :normalizepath !NewPath!
+		set NewPath=!retval!
+	)
 	if not "!NewPath!"=="" (
 		if exist !NewPath!\nul (
 			if /i not "%_ZL_ECHO%"=="" (
@@ -2553,6 +2558,8 @@ if /i "%RunMode%"=="-n" (
 			pushd !NewPath!
 			endlocal
 			goto popdir
+		) else (
+			echo The system cannot find the path specified.
 		)
 	)
 )	else (
@@ -2563,8 +2570,16 @@ goto end
 popd
 setlocal
 set "NewPath=%CD%"
-endlocal & popd & cd /d "%NewPath%"
+set "CDCmd=cd /d"
+if /i not "%_ZL_CD%"=="" (
+	set "CDCmd=%_ZL_CD%"
+)
+endlocal & popd & %CDCmd% "%NewPath%"
 :end
+exit /B
+:normalizepath
+set retval=%~f1
+exit /B
 ]]
 
 

--- a/z.lua
+++ b/z.lua
@@ -2558,8 +2558,6 @@ if /i "%RunMode%"=="-n" (
 			pushd !NewPath!
 			endlocal
 			goto popdir
-		) else (
-			echo The system cannot find the path specified.
 		)
 	)
 )	else (


### PR DESCRIPTION
- `_ZL_CD` is not being used for cmd script https://github.com/skywind3000/z.lua/issues/100#issuecomment-1024847432
- relative paths like `z ..` `z ..\..` `z scripts/subfolder` does nothing as of now, resolved the absolute paths after calling `z.lua` in this PR
