### PR TITLE
docs: added warning for powershell users

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ z -b foo    # cd to the parent directory starting with foo
 
 - Power Shell:
 
+  > ⚠️ **WARNING**: users of [Starship Prompt](https://starship.rs/) should add the following command *after* `starship init`.
+  
   put something like this in your `profile.ps1`:
 
       Invoke-Expression (& { (lua /path/to/z.lua --init powershell) -join "`n" })


### PR DESCRIPTION
`.zlua` file doesn't get created for Powershell users that use [Starship Prompt](https://starship.rs/) and place z.lua init command before starship init command in their `profile.ps1`.

Couldn't reproduce the bug in zsh. Didn't test other shells.