### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ z -b foo    # cd to the parent directory starting with foo
 
 ## Install
 
+- Fig (works with all shells)
+
+  [Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+
+    Install `z.lua` in just one click.
+
+  <a href="https://fig.io/plugins/other/z.lua" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 - Bash:
 
   put something like this in your `.bashrc`:


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

`z.lua` is already listed in the store so we'd love to have it listed as a download method on your README.

Thanks so much and please let me know if you have any questions!