### PR TITLE
Fixes and docs for the ranger plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,14 @@ At last, press `<enter>` to accept or `<ESC>` to give up.
 Remember to enable the [enhanced matching](#enhanced-matching) algorithm, the current working directory can be skipped with it.
 
 
+## Ranger integration
+To add a `:z` command to the [`ranger` file manager], copy the `ranger_zlua.py` file to `~/.config/ranger/plugins/`.
+You can then use `:z foo`, `:z -b foo`, etc. from ranger. Use `:z -h` for help.
+
+[`ranger` file manager]: https://github.com/ranger/ranger
+
+To define additional commands (`:zb` for example) in ranger, you can put `alias zb z -b` into `~/.config/ranger/rc.conf`.
+
 
 ## Tips
 

--- a/ranger_zlua.py
+++ b/ranger_zlua.py
@@ -4,8 +4,9 @@ import subprocess
 
 old_hook_init = ranger.api.hook_init
 
-PATH_LUA = os.environ.get('RANGER_LUA')
-PATH_ZLUA = os.environ.get('RANGER_ZLUA')
+# $RANGER_LUA and $RANGER_ZLUA variables are deprecated, do not use them.
+PATH_LUA = os.environ.get('RANGER_LUA') or os.environ.get('ZLUA_LUAEXE')
+PATH_ZLUA = os.environ.get('RANGER_ZLUA') or os.environ.get('ZLUA_SCRIPT')
 
 if not PATH_LUA:
     for path in os.environ.get('PATH', '').split(os.path.pathsep):
@@ -16,13 +17,15 @@ if not PATH_LUA:
                 PATH_LUA = test
                 break
 
+def _report_error(msg):
+    sys.stderr.write('ranger_zlua: ' + msg)
+    raise RuntimeError(msg)
+
 if not PATH_LUA:
-    sys.stderr.write('Please install lua or set $RANGER_LUA.\n')
-    sys.exit()
+    _report_error('Please install lua in $PATH or make sure $ZLUA_LUAEXE points to a lua executable.\n')
 
 if (not PATH_ZLUA) or (not os.path.exists(PATH_ZLUA)):
-    sys.stderr.write('Not find z.lua, please set $RANGER_ZLUA to absolute path of z.lua.\n')
-    sys.exit()
+    _report_error('Could not find z.lua, please make sure $ZLUA_SCRIPT is set to absolute path of z.lua.\n')
 
             
 def hook_init(fm):

--- a/ranger_zlua.py
+++ b/ranger_zlua.py
@@ -2,43 +2,44 @@ import time, sys, os
 import ranger.api
 import subprocess
 
-old_hook_init = ranger.api.hook_init
-
 # $RANGER_LUA and $RANGER_ZLUA variables are deprecated, do not use them.
-PATH_LUA = os.environ.get('RANGER_LUA') or os.environ.get('ZLUA_LUAEXE')
-PATH_ZLUA = os.environ.get('RANGER_ZLUA') or os.environ.get('ZLUA_SCRIPT')
+ZLUA_LUAEXE = os.environ.get('RANGER_LUA') or os.environ.get('ZLUA_LUAEXE')
+ZLUA_SCRIPT = os.environ.get('RANGER_ZLUA') or os.environ.get('ZLUA_SCRIPT')
 
-if not PATH_LUA:
+if not ZLUA_LUAEXE:
     for path in os.environ.get('PATH', '').split(os.path.pathsep):
         for name in ('lua', 'luajit', 'lua5.3', 'lua5.2', 'lua5.1'):
             test = os.path.join(path, name)
             test = test + (sys.platform[:3] == 'win' and ".exe" or "")
             if os.path.exists(test):
-                PATH_LUA = test
+                ZLUA_LUAEXE = test
                 break
 
 def _report_error(msg):
     sys.stderr.write('ranger_zlua: ' + msg)
     raise RuntimeError(msg)
 
-if not PATH_LUA:
+if not ZLUA_LUAEXE:
     _report_error('Please install lua in $PATH or make sure $ZLUA_LUAEXE points to a lua executable.\n')
-
-if (not PATH_ZLUA) or (not os.path.exists(PATH_ZLUA)):
+if (not ZLUA_SCRIPT) or (not os.path.exists(ZLUA_SCRIPT)):
     _report_error('Could not find z.lua, please make sure $ZLUA_SCRIPT is set to absolute path of z.lua.\n')
 
-            
+
+# Inform z.lua about directories the user browses to inside ranger
+old_hook_init = ranger.api.hook_init
+
 def hook_init(fm):
     def update_zlua(signal):
         import os, random
         os.environ['_ZL_RANDOM'] = str(random.randint(0, 0x7fffffff))
-        p = subprocess.Popen([PATH_LUA, PATH_ZLUA, "--add", signal.new.path])
+        p = subprocess.Popen([ZLUA_LUAEXE, ZLUA_SCRIPT, "--add", signal.new.path])
         p.wait()
-    if PATH_ZLUA and PATH_LUA and os.path.exists(PATH_ZLUA):
+    if ZLUA_SCRIPT and ZLUA_LUAEXE and os.path.exists(ZLUA_SCRIPT):
         fm.signal_bind('cd', update_zlua)
     return old_hook_init(fm)
 
 ranger.api.hook_init = hook_init
+
 
 class z(ranger.api.commands.Command):
     def execute (self):
@@ -55,13 +56,13 @@ class z(ranger.api.commands.Command):
                 elif arg[:1] != '-':
                     break
             if mode:
-                cmd = '"%s" "%s" '%(PATH_LUA, PATH_ZLUA)
+                cmd = '"%s" "%s" '%(ZLUA_LUAEXE, ZLUA_SCRIPT)
                 if mode in ('-I', '-i', '--'):
                     cmd += ' --cd'
                 for arg in args:
                     cmd += ' "%s"'%arg
                 if mode in ('-e', '-x'):
-                    path = subprocess.check_output([PATH_LUA, PATH_ZLUA, '--cd'] + args)
+                    path = subprocess.check_output([ZLUA_LUAEXE, ZLUA_SCRIPT, '--cd'] + args)
                     path = path.decode("utf-8", "ignore")
                     path = path.rstrip('\n')
                     self.fm.notify(path)
@@ -79,7 +80,7 @@ class z(ranger.api.commands.Command):
                     if path and os.path.exists(path):
                         self.fm.cd(path)
             else:
-                path = subprocess.check_output([PATH_LUA, PATH_ZLUA, '--cd'] + args)
+                path = subprocess.check_output([ZLUA_LUAEXE, ZLUA_SCRIPT, '--cd'] + args)
                 path = path.decode("utf-8", "ignore")
                 path = path.rstrip('\n')
                 if path and os.path.exists(path):


### PR DESCRIPTION
Makes Ranger plugin use the standard `$ZLUA_LUAEXE` and `$ZLUA_SCRIPT`
environment variables that `z.lua`, fixes error handling, adds docs.