### PR TITLE
fix potential compatibilty issue for some fish shell versions and add…

### DIFF
--- a/z.lua
+++ b/z.lua
@@ -2423,7 +2423,9 @@ function _zlua
 end
 
 if test -z "$_ZL_CMD"; set -x _ZL_CMD z; end
-alias "$_ZL_CMD"=_zlua
+function $_ZL_CMD -w _zlua -d "alias $_ZL_CMD=_zlua"
+	_zlua $argv
+end
 ]]
 
 script_init_fish = [[


### PR DESCRIPTION
… autocompletion for cmd options

1. `alias` command not available in some fishshell versions like 3.3.1. use fish-native `function` instead;
2. add autocompletion for cmd options benefitting from magic power of fish. just type `z -` and press tab. enjoy yourself.