### PR TITLE
Make z.lua try treating `-` as a normal character if there are no results

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,12 @@ z -b foo bar # replace foo with bar in cwd and cd there
 - set `$_ZL_ECHO` to 1 to display new directory name after cd.
 - set `$_ZL_MATCH_MODE` to 1 to enable enhanced matching.
 - set `$_ZL_NO_CHECK` to 1 to disable path validation, use `z --purge` to clean
-- set `$_ZL_HYPHEN` to 1 to treat hyphon (-) as a normal character not a lua regexp keyword.
+- set `$_ZL_HYPHEN` to 0 to treat a hyphen (`-`) as a
+  [lua regexp special character](https://www.lua.org/pil/20.2.html),
+  set `$_ZL_HYPHEN` to 1 to treat a hyphen as a normal character.
+  If `$_ZL_HYPHEN` is not set or if it is set to `auto`, z.lua tries to treat `-`
+  as a lua regexp special character first. If there are no matches, z.lua tries
+  again, this time treating `-` as a normal character.
 - set `$_ZL_CLINK_PROMPT_PRIORITY` change clink prompt register priority (default 99).
 
 ## Aging


### PR DESCRIPTION
Previously, you needed to set `_ZL_HYPHEN=1` to treat `-` as a normal
character.  Otherwise, it was treated as a Lua regexp special character, see
https://www.lua.org/pil/20.2.html. Note that it is not super-useful to treat
`-` as a special character; it is almost the same as `*` and the difference
is not very useful in the context of fuzzy matching.

Now, if `_ZL_HYPHEN` is not set, z.lua first tries to treat it as a regexp
character. If there are no results (which is likely if the user does not know
it's a special character), z.lua tries again, treating `-` as a normal
character this time.

If `_ZL_HYPHEN=0` or `_ZL_HYPHEN=1`, z.lua will always treat `-` as
either a regex symbol or as a normal character (respectively).

Hopefully, this will make the FAQ at
https://github.com/skywind3000/z.lua/wiki/FAQ#how-to-input-a-hyphen---in-the-keyword-
unnecessary.  It took me weeks to look into the question of why `z
home-manager` refused to work and to find that FAQ.

I only tested this briefly, but it seems to work.
