### PR TITLE
Fix invalid pathname in `z -I xyz` on Windows.

### DIFF
--- a/z.lua
+++ b/z.lua
@@ -1676,7 +1676,7 @@ function z_cd(patterns)
 			end
 			cmd = cmd .. ' < "' .. tmpname .. '"'
 		else
-			tmpname = os.tmpname():gsub('\\', ''):gsub('%.', '')
+			tmpname = os.tmpname():gsub('[\\:]', ''):gsub('%.', '')
 			tmpname = os.environ('TMP', '') .. '\\zlua_' .. tmpname .. '.txt'
 			cmd = 'type "' .. tmpname .. '" | ' .. cmd
 		end
@@ -1873,7 +1873,7 @@ function cd_breadcrumbs(pwd, interactive)
 		if not windows then
 			tmpname = os.tmpname()
 		else
-			tmpname = os.tmpname():gsub('\\', ''):gsub('%.', '')
+			tmpname = os.tmpname():gsub('[\\:]', ''):gsub('%.', '')
 			tmpname = os.environ('TMP', '') .. '\\zlua_' .. tmpname .. '.txt'
 		end
 		fp = io.open(tmpname, 'w')


### PR DESCRIPTION
The fzf interactive mode (`-I`) constructs a `tmpname` pathname and tries to sanitize it by stripping all `\` characters.  But it missed stripping all `:` characters, and the command printed this error output:

```
The filename, directory name, or volume label syntax is incorrect.
```

The `tmpname` looked like "c:\tmp\Temp\zlua_c:tmpTempsh2k0.txt", and the embedded `:` caused the error output.

This commit adds `:` to the list of characters to be stripped (only on Windows).