### PR TITLE
Fix when _ZL_MATCH_MODE=1.

### DIFF
--- a/z.lua
+++ b/z.lua
@@ -1979,7 +1979,7 @@ function main(argv)
 			path = z_cd(args)
 			if path == nil and Z_MATCHMODE ~= 0 then
 				local last = args[#args]
-				if os.path.isdir(last) then
+				if last and os.path.isdir(last) then
 					path = os.path.abspath(last)
 					path = os.path.norm(path)
 				end


### PR DESCRIPTION
When _ZL_MATCH_MODE=1 a script error occurs after `z -I` and <kbd>Ctrl</kbd>-<kbd>D</kbd>.

The code is missing a nil check.