### PR TITLE
fix: don't reassign for-loop variable

### DIFF
--- a/z.lua
+++ b/z.lua
@@ -235,7 +235,8 @@ end
 function dump(o)
 	if type(o) == 'table' then
 		local s = '{ '
-		for k,v in pairs(o) do
+		for key,v in pairs(o) do
+			local k = key
 			if type(k) ~= 'number' then k = '"'..k..'"' end
 			s = s .. '['..k..'] = ' .. dump(v) .. ','
 		end


### PR DESCRIPTION
In Lua 5.5 you can no longer reassign for-loop variables, f.e.

```lua
for k, v in pairs(tbl) do k = "foobar" end
```

This PR should fix this problem

Related to https://github.com/Homebrew/homebrew-core/pull/259732